### PR TITLE
Added a "setup" action to the configuration selection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,7 @@ Config Store
 
 - Stores configurations and are retrievable as a dictionary
 - Configurations are lazily loaded and are cached per request
+- Configurations can have a Setup action to run one-time requests dependent on the configuration data
 - Configuration is defined as a django form
 
 Installation
@@ -23,11 +24,25 @@ Define your configuration form somewhere::
     
     from configstore.configs import ConfigurationInstance, register
     from configstore.forms import ConfigurationForm
+
+    import logging
     
     class ExampleConfigurationForm(ConfigurationForm):
         amount = forms.DecimalField()
         message = forms.CharField()
         user = forms.ModelChoiceField(queryset=User.objects.all())
+
+        @staticmethod
+        def config_task(configuration):
+            """
+            Params:
+                configuration - Instance of django-configstore.models.Configuration
+
+            Return:
+                Message to be echo'ed back to the user through "message_user".
+            """
+            logging.info("You just ran the configuration action for %s!" % unicode(configuration.name) )
+            return "Yay, you've accomplished nothing!"
 
 Register the form::
 

--- a/README.rst
+++ b/README.rst
@@ -34,13 +34,6 @@ Define your configuration form somewhere::
 
         @staticmethod
         def config_task(configuration):
-            """
-            Params:
-                configuration - Instance of django-configstore.models.Configuration
-
-            Return:
-                Message to be echo'ed back to the user through "message_user".
-            """
             logging.info("You just ran the configuration action for %s!" % unicode(configuration.name) )
             return "Yay, you've accomplished nothing!"
 

--- a/configstore/admin.py
+++ b/configstore/admin.py
@@ -12,6 +12,14 @@ from configs import CONFIGS
 class ConfigurationAdmin(admin.ModelAdmin):
     list_display = ('name', 'key', 'site')
 
+    actions = ['run_setup']
+
+    def run_setup(self, request, queryset):
+        for item in queryset:
+            setup_task = CONFIGS.get(item.key).form.config_task
+            self.message_user(request, setup_task(item))
+    run_setup.short_description = "Run the setup task for the configuration"
+
     def get_fieldsets(self, request, obj=None):
         #consider it might be nice delegate more of this functionality to the ConfigurationInstance
         form_builder = self.get_form(request, obj)

--- a/configstore/forms.py
+++ b/configstore/forms.py
@@ -34,4 +34,11 @@ class ConfigurationForm(forms.ModelForm):
 
     @staticmethod
     def config_task(configuration):
+        """
+        Params:
+            configuration - Instance of django-configstore.models.Configuration
+
+        Return:
+            Message to be echo'ed back to the user through "message_user".
+        """
         return "No task defined for %s." % configuration.name

--- a/configstore/forms.py
+++ b/configstore/forms.py
@@ -32,4 +32,6 @@ class ConfigurationForm(forms.ModelForm):
         model = Configuration
         fields = ['site']
 
-
+    @staticmethod
+    def config_task(configuration):
+        return "No task defined for %s." % configuration.name


### PR DESCRIPTION
The idea is that some forms could use a way to run setup tasks - maybe you need to alter the state of something based on what you key into a configuration.

For example, if you have a configuration with a shared secret, you can configure the "setup" action to contact the other party and distribute the shared secret.
